### PR TITLE
Added support for all progress tokens effects

### DIFF
--- a/src/main/java/com/isep/game/Game.java
+++ b/src/main/java/com/isep/game/Game.java
@@ -81,10 +81,10 @@ public class Game
             {
                 this.outputManager.displayPlayerTurn(player);
 
-                boolean pickAgain = true;
-                while(pickAgain)
+                int cardsToPick = 1;
+                while(cardsToPick > 0)
                 {
-                    pickAgain = false;
+                    cardsToPick--;
 
                     // Pick a card from one of the three available decks
                     // (the Player's deck (aka the left deck), the next player's deck (aka the right deck) or the central deck
@@ -112,16 +112,26 @@ public class Game
                         // Bonuses granted by progress tokens
                         // TODO: display message to player indicating why they got to pick another card
                         if(((GreyCard) pickedCard).getMaterial() == GreyCard.Material.WOOD || ((GreyCard) pickedCard).getMaterial() == GreyCard.Material.BRICK)
-                            pickAgain = player.hasProgressTokenEffect(ProgressToken.Effect.URBANISM);
+                        {
+                            if(player.hasProgressTokenEffect(ProgressToken.Effect.URBANISM))
+                                cardsToPick++;
+                        }
                         if(((GreyCard) pickedCard).getMaterial() == GreyCard.Material.PAPYRUS || ((GreyCard) pickedCard).getMaterial() == GreyCard.Material.GLASS)
-                            pickAgain = player.hasProgressTokenEffect(ProgressToken.Effect.CRAFTS);
+                        {
+                            if(player.hasProgressTokenEffect(ProgressToken.Effect.CRAFTS))
+                                cardsToPick++;
+                        }
                         if(((GreyCard) pickedCard).getMaterial() == GreyCard.Material.STONE)
-                            pickAgain = player.hasProgressTokenEffect(ProgressToken.Effect.JEWELLERY);
+                        {
+                            if(player.hasProgressTokenEffect(ProgressToken.Effect.JEWELLERY))
+                                cardsToPick++;
+                        }
                     }
                     if(pickedCard instanceof YellowCard)
                     {
                         // Bonuses granted by progress tokens
-                        pickAgain = player.hasProgressTokenEffect(ProgressToken.Effect.JEWELLERY);
+                        if(player.hasProgressTokenEffect(ProgressToken.Effect.JEWELLERY))
+                            cardsToPick++;
                     }
                     if(pickedCard instanceof BlueCard)
                     {
@@ -136,7 +146,8 @@ public class Game
                     else if(pickedCard instanceof GreenCard)
                     {
                         // Bonuses granted by progress tokens
-                        pickAgain = player.hasProgressTokenEffect(ProgressToken.Effect.SCIENCE);
+                        if(player.hasProgressTokenEffect(ProgressToken.Effect.SCIENCE))
+                            cardsToPick++;
 
                         if(player.getHand().containsTwoIdenticalScienceSymbols() || player.getHand().containsThreeDifferentScienceSymbols())
                             player.addProgressToken(this.inputParser.fetchProgressTokenFromStack(this.progressTokenStack));
@@ -145,7 +156,10 @@ public class Game
                     {
                         // Bonuses granted by progress tokens
                         if(((RedCard) pickedCard).getHorns() > 0)
-                            pickAgain = player.hasProgressTokenEffect(ProgressToken.Effect.PROPAGANDA);
+                        {
+                            if(player.hasProgressTokenEffect(ProgressToken.Effect.PROPAGANDA))
+                                cardsToPick++;
+                        }
 
                         this.conflictTokensBattleSide += ((RedCard) pickedCard).getHorns();
                         // TODO: battle should be started at the end of the Player's turn

--- a/src/main/java/com/isep/game/Game.java
+++ b/src/main/java/com/isep/game/Game.java
@@ -143,6 +143,10 @@ public class Game
                     }
                     else if(pickedCard instanceof RedCard)
                     {
+                        // Bonuses granted by progress tokens
+                        if(((RedCard) pickedCard).getHorns() > 0)
+                            pickAgain = player.hasProgressTokenEffect(ProgressToken.Effect.PROPAGANDA);
+
                         this.conflictTokensBattleSide += ((RedCard) pickedCard).getHorns();
                         // TODO: battle should be started at the end of the Player's turn
                         if(this.conflictTokensBattleSide >= this.conflictTokensAmount)

--- a/src/main/java/com/isep/game/Game.java
+++ b/src/main/java/com/isep/game/Game.java
@@ -100,6 +100,10 @@ public class Game
                     // If possible, it builds the first available Stage that can be built
                     if(player.getHand().canBuildStage(player.getWonder().getNextStagesToBuild()))
                     {
+                        // Bonuses granted by progress tokens
+                        if(player.hasProgressTokenEffect(ProgressToken.Effect.ARCHITECTURE))
+                            cardsToPick++;
+
                         List<Stage> stagesReadyToBuild = player.getHand().getStagesReadyToBuild(player.getWonder().getNextStagesToBuild());
                         // TODO: add the ability to let the Player chose the Stage to build if multiple are available
                         player.getWonder().buildStage(stagesReadyToBuild.get(0), player.getHand(), this.discard);

--- a/src/main/java/com/isep/game/Game.java
+++ b/src/main/java/com/isep/game/Game.java
@@ -29,7 +29,7 @@ public class Game
      */
     private Deck discard;
     /**
-     * The {@link ProgressTokenStack} in which every {@link Player} can pick a {@link ProgressToken} when possible..
+     * The {@link ProgressTokenStack} in which every {@link Player} can pick a {@link ProgressToken} when possible.
      */
     private ProgressTokenStack progressTokenStack;
     /**
@@ -65,6 +65,7 @@ public class Game
         return this.discard;
     }
 
+    // Methods
     /**
      * Starts the {@link Game} and stops automatically when a {@link Player}'s {@link Wonder} has been entirely constructed.
      * @throws ExecutionControl.NotImplementedException
@@ -80,47 +81,63 @@ public class Game
             {
                 this.outputManager.displayPlayerTurn(player);
 
-                // Pick a card from one of the three available decks
-                // (the Player's deck (aka the left deck), the next player's deck (aka the right deck) or the central deck
-                int nextPlayerIndex = this.players.indexOf(player) + 1;
-                if(nextPlayerIndex >= this.players.size())
-                    nextPlayerIndex = 0;
-                Card pickedCard = this.inputParser.fetchCardFromDeck(player.getDeck(), this.players.get(nextPlayerIndex).getDeck(), this.centralDeck);
-                player.getHand().addCard(pickedCard);
-
-                this.outputManager.displayPlayerHand(player);
-
-                // Checks if the player can build a Stage of its Wonder
-                // If possible, it builds the first available Stage that can be built
-                if(player.getHand().canBuildStage(player.getWonder().getNextStagesToBuild()))
+                boolean pickAgain = true;
+                while(pickAgain)
                 {
-                    List<Stage> stagesReadyToBuild = player.getHand().getStagesReadyToBuild(player.getWonder().getNextStagesToBuild());
-                    // TODO: add the ability to let the Player chose the Stage to build if multiple are available
-                    player.getWonder().buildStage(stagesReadyToBuild.get(0), player.getHand(), this.discard);
-                    this.outputManager.displayStageBuilt(player, stagesReadyToBuild.get(0), player.getWonder());
-                }
+                    pickAgain = false;
 
-                if(pickedCard instanceof BlueCard)
-                {
-                    if(((BlueCard) pickedCard).getCat())
+                    // Pick a card from one of the three available decks
+                    // (the Player's deck (aka the left deck), the next player's deck (aka the right deck) or the central deck
+                    int nextPlayerIndex = this.players.indexOf(player) + 1;
+                    if(nextPlayerIndex >= this.players.size())
+                        nextPlayerIndex = 0;
+                    Card pickedCard = this.inputParser.fetchCardFromDeck(player.getDeck(), this.players.get(nextPlayerIndex).getDeck(), this.centralDeck);
+                    player.getHand().addCard(pickedCard);
+
+                    this.outputManager.displayPlayerHand(player);
+
+                    // Checks if the player can build a Stage of its Wonder
+                    // If possible, it builds the first available Stage that can be built
+                    if(player.getHand().canBuildStage(player.getWonder().getNextStagesToBuild()))
                     {
-                        for(Player p: this.players)
-                            p.setHasCat(false);
-                        player.setHasCat(true);
-                        player.addVictoryPoints(((BlueCard) pickedCard).getVictoryPoints());
+                        List<Stage> stagesReadyToBuild = player.getHand().getStagesReadyToBuild(player.getWonder().getNextStagesToBuild());
+                        // TODO: add the ability to let the Player chose the Stage to build if multiple are available
+                        player.getWonder().buildStage(stagesReadyToBuild.get(0), player.getHand(), this.discard);
+                        this.outputManager.displayStageBuilt(player, stagesReadyToBuild.get(0), player.getWonder());
                     }
-                }
-                else if(pickedCard instanceof GreenCard)
-                {
-                    if(player.getHand().containsTwoIdenticalScienceSymbols() || player.getHand().containsThreeDifferentScienceSymbols())
-                        player.addProgressToken(this.inputParser.fetchProgressTokenFromStack(this.progressTokenStack));
-                }
-                else if(pickedCard instanceof RedCard)
-                {
-                    this.conflictTokensBattleSide += ((RedCard) pickedCard).getHorns();
-                    // TODO: battle should be started at the end of the Player's turn
-                    if(this.conflictTokensBattleSide >= this.conflictTokensAmount)
-                        this.resolveBattle();
+
+                    // Checking player's bonuses
+                    if(pickedCard instanceof GreyCard)
+                    {
+                        // TODO: display message to player indicating why they got to pick another card
+                        if(((GreyCard) pickedCard).getMaterial() == GreyCard.Material.WOOD || ((GreyCard) pickedCard).getMaterial() == GreyCard.Material.BRICK)
+                            pickAgain = player.hasProgressTokenEffect(ProgressToken.Effect.URBANISM);
+                        if(((GreyCard) pickedCard).getMaterial() == GreyCard.Material.PAPYRUS || ((GreyCard) pickedCard).getMaterial() == GreyCard.Material.GLASS)
+                            pickAgain = player.hasProgressTokenEffect(ProgressToken.Effect.CRAFTS);
+                    }
+
+                    if(pickedCard instanceof BlueCard)
+                    {
+                        if(((BlueCard) pickedCard).getCat())
+                        {
+                            for(Player p: this.players)
+                                p.setHasCat(false);
+                            player.setHasCat(true);
+                            player.addVictoryPoints(((BlueCard) pickedCard).getVictoryPoints());
+                        }
+                    }
+                    else if(pickedCard instanceof GreenCard)
+                    {
+                        if(player.getHand().containsTwoIdenticalScienceSymbols() || player.getHand().containsThreeDifferentScienceSymbols())
+                            player.addProgressToken(this.inputParser.fetchProgressTokenFromStack(this.progressTokenStack));
+                    }
+                    else if(pickedCard instanceof RedCard)
+                    {
+                        this.conflictTokensBattleSide += ((RedCard) pickedCard).getHorns();
+                        // TODO: battle should be started at the end of the Player's turn
+                        if(this.conflictTokensBattleSide >= this.conflictTokensAmount)
+                            this.resolveBattle();
+                    }
                 }
             }
         }

--- a/src/main/java/com/isep/game/Game.java
+++ b/src/main/java/com/isep/game/Game.java
@@ -107,7 +107,10 @@ public class Game
                         List<Stage> stagesReadyToBuild = player.getHand().getStagesReadyToBuild(player.getWonder().getNextStagesToBuild(), player.hasProgressTokenEffect(ProgressToken.Effect.ECONOMY), player.hasProgressTokenEffect(ProgressToken.Effect.ENGINEERING));
                         // TODO: add the ability to let the Player chose the Stage to build if multiple are available
                         player.getWonder().buildStage(stagesReadyToBuild.get(0), player.getHand(), this.discard, player.hasProgressTokenEffect(ProgressToken.Effect.ECONOMY), player.hasProgressTokenEffect(ProgressToken.Effect.ENGINEERING));
+                        player.addVictoryPoints(stagesReadyToBuild.get(0).getVictoryPoints());
                         this.outputManager.displayStageBuilt(player, stagesReadyToBuild.get(0), player.getWonder());
+
+                        this.onePlayerBuiltItsWonder = player.getWonder().isConstructed();
                     }
 
                     // Parsing actions depending on the color of the picked card
@@ -174,7 +177,9 @@ public class Game
             }
         }
 
-        //TODO: calculate points
+        this.calculateVictoryPoints();
+        //TODO: display results
+        //this.outputManager.displayResults();
     }
 
     /**
@@ -236,6 +241,7 @@ public class Game
      * wins the battle and earns 1 military victory token (1 victory point) per beaten neighbor. All {@link RedCard} with 1 or 2
      * horns must be discarded at the end of the battle.
      */
+    // TODO: this probably breaks if there are only two players
     private void resolveBattle()
     {
         int leftPlayerIndex;
@@ -264,9 +270,9 @@ public class Game
 
             // If a draw occurs, no points are awarded.
             if((player.getHand().getNumberOfShields() + additionalShields) > leftPlayer.getHand().getNumberOfShields())
-                player.addVictoryPoints(1);
+                player.addMilitaryVictoryTokens(1);
             if((player.getHand().getNumberOfShields() + additionalShields) > rightPlayer.getHand().getNumberOfShields())
-                player.addVictoryPoints(1);
+                player.addMilitaryVictoryTokens(1);
 
             this.conflictTokensBattleSide = 0;
         }
@@ -351,5 +357,36 @@ public class Game
         this.progressTokenStack.addProgressToken(new ProgressToken(ProgressToken.Effect.STRATEGY));
         this.progressTokenStack.addProgressToken(new ProgressToken(ProgressToken.Effect.EDUCATION));
         this.progressTokenStack.addProgressToken(new ProgressToken(ProgressToken.Effect.CULTURE), 2);
+    }
+
+    /**
+     * Calculates and updates each {@link Player}'s victory points.
+     * This takes {@link ProgressToken} effects into account.
+     */
+    private void calculateVictoryPoints()
+    {
+        for(Player player: this.players)
+        {
+            // Bonuses granted by progress tokens
+            if(player.hasProgressTokenEffect(ProgressToken.Effect.DECOR))
+            {
+                if(player.getWonder().isConstructed())
+                    player.addVictoryPoints(6);
+                else
+                    player.addVictoryPoints(4);
+            }
+            if(player.hasProgressTokenEffect(ProgressToken.Effect.POLITICS))
+                player.addVictoryPoints(player.getHand().getNumberOfCats());
+            if(player.hasProgressTokenEffect(ProgressToken.Effect.STRATEGY))
+                player.addVictoryPoints(player.getMilitaryVictoryTokens() * 2);
+            else
+                player.addVictoryPoints(player.getMilitaryVictoryTokens());
+            if(player.hasProgressTokenEffect(ProgressToken.Effect.EDUCATION))
+                player.addVictoryPoints((player.getProgressTokens().size()) * 2);
+            if(player.hasProgressTokenEffect(ProgressToken.Effect.CULTURE, 1))
+                player.addVictoryPoints(4);
+            if(player.hasProgressTokenEffect(ProgressToken.Effect.CULTURE, 2))
+                player.addVictoryPoints(12);
+        }
     }
 }

--- a/src/main/java/com/isep/game/Game.java
+++ b/src/main/java/com/isep/game/Game.java
@@ -256,10 +256,14 @@ public class Game
             player = this.players.get(i);
             rightPlayer = this.players.get(rightPlayerIndex);
 
+            int additionalShields = 0;
+            if(player.hasProgressTokenEffect(ProgressToken.Effect.TACTICS))
+                additionalShields = 2;
+
             // If a draw occurs, no points are awarded.
-            if(player.getHand().getNumberOfShields() > leftPlayer.getHand().getNumberOfShields())
+            if((player.getHand().getNumberOfShields() + additionalShields) > leftPlayer.getHand().getNumberOfShields())
                 player.addVictoryPoints(1);
-            if(player.getHand().getNumberOfShields() > rightPlayer.getHand().getNumberOfShields())
+            if((player.getHand().getNumberOfShields() + additionalShields) > rightPlayer.getHand().getNumberOfShields())
                 player.addVictoryPoints(1);
 
             this.conflictTokensBattleSide = 0;

--- a/src/main/java/com/isep/game/Game.java
+++ b/src/main/java/com/isep/game/Game.java
@@ -98,15 +98,15 @@ public class Game
 
                     // Checks if the player can build a Stage of its Wonder
                     // If possible, it builds the first available Stage that can be built
-                    if(player.getHand().canBuildStage(player.getWonder().getNextStagesToBuild()))
+                    if(player.getHand().canBuildStage(player.getWonder().getNextStagesToBuild(), player.hasProgressTokenEffect(ProgressToken.Effect.ECONOMY)))
                     {
                         // Bonuses granted by progress tokens
                         if(player.hasProgressTokenEffect(ProgressToken.Effect.ARCHITECTURE))
                             cardsToPick++;
 
-                        List<Stage> stagesReadyToBuild = player.getHand().getStagesReadyToBuild(player.getWonder().getNextStagesToBuild());
+                        List<Stage> stagesReadyToBuild = player.getHand().getStagesReadyToBuild(player.getWonder().getNextStagesToBuild(), player.hasProgressTokenEffect(ProgressToken.Effect.ECONOMY));
                         // TODO: add the ability to let the Player chose the Stage to build if multiple are available
-                        player.getWonder().buildStage(stagesReadyToBuild.get(0), player.getHand(), this.discard);
+                        player.getWonder().buildStage(stagesReadyToBuild.get(0), player.getHand(), this.discard, player.hasProgressTokenEffect(ProgressToken.Effect.ECONOMY));
                         this.outputManager.displayStageBuilt(player, stagesReadyToBuild.get(0), player.getWonder());
                     }
 
@@ -173,6 +173,8 @@ public class Game
                 }
             }
         }
+
+        //TODO: calculate points
     }
 
     /**

--- a/src/main/java/com/isep/game/Game.java
+++ b/src/main/java/com/isep/game/Game.java
@@ -98,15 +98,15 @@ public class Game
 
                     // Checks if the player can build a Stage of its Wonder
                     // If possible, it builds the first available Stage that can be built
-                    if(player.getHand().canBuildStage(player.getWonder().getNextStagesToBuild(), player.hasProgressTokenEffect(ProgressToken.Effect.ECONOMY)))
+                    if(player.getHand().canBuildStage(player.getWonder().getNextStagesToBuild(), player.hasProgressTokenEffect(ProgressToken.Effect.ECONOMY), player.hasProgressTokenEffect(ProgressToken.Effect.ENGINEERING)))
                     {
                         // Bonuses granted by progress tokens
                         if(player.hasProgressTokenEffect(ProgressToken.Effect.ARCHITECTURE))
                             cardsToPick++;
 
-                        List<Stage> stagesReadyToBuild = player.getHand().getStagesReadyToBuild(player.getWonder().getNextStagesToBuild(), player.hasProgressTokenEffect(ProgressToken.Effect.ECONOMY));
+                        List<Stage> stagesReadyToBuild = player.getHand().getStagesReadyToBuild(player.getWonder().getNextStagesToBuild(), player.hasProgressTokenEffect(ProgressToken.Effect.ECONOMY), player.hasProgressTokenEffect(ProgressToken.Effect.ENGINEERING));
                         // TODO: add the ability to let the Player chose the Stage to build if multiple are available
-                        player.getWonder().buildStage(stagesReadyToBuild.get(0), player.getHand(), this.discard, player.hasProgressTokenEffect(ProgressToken.Effect.ECONOMY));
+                        player.getWonder().buildStage(stagesReadyToBuild.get(0), player.getHand(), this.discard, player.hasProgressTokenEffect(ProgressToken.Effect.ECONOMY), player.hasProgressTokenEffect(ProgressToken.Effect.ENGINEERING));
                         this.outputManager.displayStageBuilt(player, stagesReadyToBuild.get(0), player.getWonder());
                     }
 

--- a/src/main/java/com/isep/game/Game.java
+++ b/src/main/java/com/isep/game/Game.java
@@ -114,6 +114,12 @@ public class Game
                             pickAgain = player.hasProgressTokenEffect(ProgressToken.Effect.URBANISM);
                         if(((GreyCard) pickedCard).getMaterial() == GreyCard.Material.PAPYRUS || ((GreyCard) pickedCard).getMaterial() == GreyCard.Material.GLASS)
                             pickAgain = player.hasProgressTokenEffect(ProgressToken.Effect.CRAFTS);
+                        if(((GreyCard) pickedCard).getMaterial() == GreyCard.Material.STONE)
+                            pickAgain = player.hasProgressTokenEffect(ProgressToken.Effect.JEWELLERY);
+                    }
+                    if(pickedCard instanceof YellowCard)
+                    {
+                        pickAgain = player.hasProgressTokenEffect(ProgressToken.Effect.JEWELLERY);
                     }
 
                     if(pickedCard instanceof BlueCard)

--- a/src/main/java/com/isep/game/Game.java
+++ b/src/main/java/com/isep/game/Game.java
@@ -106,9 +106,10 @@ public class Game
                         this.outputManager.displayStageBuilt(player, stagesReadyToBuild.get(0), player.getWonder());
                     }
 
-                    // Checking player's bonuses
+                    // Parsing actions depending on the color of the picked card
                     if(pickedCard instanceof GreyCard)
                     {
+                        // Bonuses granted by progress tokens
                         // TODO: display message to player indicating why they got to pick another card
                         if(((GreyCard) pickedCard).getMaterial() == GreyCard.Material.WOOD || ((GreyCard) pickedCard).getMaterial() == GreyCard.Material.BRICK)
                             pickAgain = player.hasProgressTokenEffect(ProgressToken.Effect.URBANISM);
@@ -119,9 +120,9 @@ public class Game
                     }
                     if(pickedCard instanceof YellowCard)
                     {
+                        // Bonuses granted by progress tokens
                         pickAgain = player.hasProgressTokenEffect(ProgressToken.Effect.JEWELLERY);
                     }
-
                     if(pickedCard instanceof BlueCard)
                     {
                         if(((BlueCard) pickedCard).getCat())
@@ -134,6 +135,9 @@ public class Game
                     }
                     else if(pickedCard instanceof GreenCard)
                     {
+                        // Bonuses granted by progress tokens
+                        pickAgain = player.hasProgressTokenEffect(ProgressToken.Effect.SCIENCE);
+
                         if(player.getHand().containsTwoIdenticalScienceSymbols() || player.getHand().containsThreeDifferentScienceSymbols())
                             player.addProgressToken(this.inputParser.fetchProgressTokenFromStack(this.progressTokenStack));
                     }

--- a/src/main/java/com/isep/game/Player.java
+++ b/src/main/java/com/isep/game/Player.java
@@ -3,6 +3,7 @@ package com.isep.game;
 import com.isep.game.cards.Deck;
 import com.isep.game.cards.Hand;
 import com.isep.game.tokens.ProgressToken;
+import com.isep.game.tokens.ProgressToken.Effect;
 import com.isep.game.wonders.Wonder;
 
 import java.time.LocalDate;
@@ -98,6 +99,22 @@ public class Player implements Comparable<Player>
     public void addProgressToken(ProgressToken token)
     {
         this.progressTokens.add(token);
+    }
+
+    /**
+     * Returns true if this {@link Player} has a {@link ProgressToken} with the provided {@link Effect}.
+     * @param effect The {@link Effect} to check for.
+     * @return True if this {@link Player} has the provided {@link Effect}.
+     */
+    public boolean hasProgressTokenEffect(ProgressToken.Effect effect)
+    {
+        for(ProgressToken token: this.progressTokens)
+        {
+            if(token.getEffect() == effect)
+                return true;
+        }
+
+        return false;
     }
 
     @Override

--- a/src/main/java/com/isep/game/Player.java
+++ b/src/main/java/com/isep/game/Player.java
@@ -23,6 +23,7 @@ public class Player implements Comparable<Player>
     private Deck deck;
     private Hand hand;
     private List<ProgressToken> progressTokens;
+    private int militaryVictoryTokens;
     private int victoryPoints;
     private boolean hasCat;
 
@@ -35,6 +36,7 @@ public class Player implements Comparable<Player>
         this.deck = this.wonder.getDeck();
         this.hand = new Hand();
         this.progressTokens = new ArrayList<ProgressToken>();
+        this.militaryVictoryTokens = 0;
         this.victoryPoints = 0;
         this.hasCat = false;
     }
@@ -70,6 +72,11 @@ public class Player implements Comparable<Player>
         return this.progressTokens;
     }
 
+    public int getMilitaryVictoryTokens()
+    {
+        return this.militaryVictoryTokens;
+    }
+
     public boolean hasCat()
     {
         return this.hasCat;
@@ -81,6 +88,16 @@ public class Player implements Comparable<Player>
     }
 
     // Methods
+    /**
+     * Increments this {@link Player}'s amount of military victory tokens.
+     * @param militaryVictoryTokens The amount of military victory tokens points to add.
+     * @author Quentin LAURENT
+     */
+    public void addMilitaryVictoryTokens(int militaryVictoryTokens)
+    {
+        this.militaryVictoryTokens += militaryVictoryTokens;
+    }
+
     /**
      * Increments this {@link Player}'s amount of victory points.
      * @param victoryPoints The amount of victory points to add.
@@ -115,6 +132,25 @@ public class Player implements Comparable<Player>
         }
 
         return false;
+    }
+
+    /**
+     * Returns true if this {@link Player} has the exact quantity of {@link ProgressToken} with the provided {@link Effect}.
+     * @param effect The {@link Effect} to check for.
+     * @param exactQuantity The exact quantity of the provided {@link Effect}.
+     * @return True if this {@link Player} has the exact quantity of the {@link Effect}.
+     */
+    public boolean hasProgressTokenEffect(ProgressToken.Effect effect, int exactQuantity)
+    {
+        int quantity = 0;
+
+        for(ProgressToken token: this.progressTokens)
+        {
+            if(token.getEffect() == effect)
+                quantity++;
+        }
+
+        return (quantity == exactQuantity);
     }
 
     @Override

--- a/src/main/java/com/isep/game/cards/GreyCard.java
+++ b/src/main/java/com/isep/game/cards/GreyCard.java
@@ -23,6 +23,12 @@ public class GreyCard extends Card
         this.material = material;
     }
 
+    // Getters & Setters
+    public Material getMaterial()
+    {
+        return this.material;
+    }
+
     // Methods
     @Override
     public String toString()

--- a/src/main/java/com/isep/game/cards/Hand.java
+++ b/src/main/java/com/isep/game/cards/Hand.java
@@ -502,6 +502,23 @@ public class Hand
         this.cards.entrySet().removeIf(entry -> entry.getKey() instanceof RedCard && ((RedCard) entry.getKey()).getHorns() > 0);
     }
 
+    /**
+     * Returns the number of cats ({@link BlueCard}s with the Cat symbol) of this {@link Hand}.
+     * @return The number of cats contained in this {@link Hand}.
+     */
+    public int getNumberOfCats()
+    {
+        int numberOfCats = 0;
+
+        for(var entry: this.cards.entrySet())
+        {
+            if(entry.getKey() instanceof BlueCard && ((BlueCard) entry.getKey()).getCat())
+                numberOfCats++;
+        }
+
+        return numberOfCats;
+    }
+
     @Override
     public String toString()
     {

--- a/src/main/java/com/isep/game/cards/Hand.java
+++ b/src/main/java/com/isep/game/cards/Hand.java
@@ -276,8 +276,10 @@ public class Hand
      * @param stage The {@link Stage} to build.
      * @param economyEffect A boolean indicating if the {@link Player} owning this {@link Hand} has the ECONOMY {@link ProgressToken}.
      * @return A {@link Map} containing the {@link Card}s required.
+     * @deprecated Needs rewriting.
      * @author Quentin LAURENT
      */
+    @Deprecated
     public Map<Card, Integer> getCardsRequiredToBuildStage(Stage stage, boolean economyEffect)
     {
         float bonus = (economyEffect) ? 2f : 1f;

--- a/src/main/java/com/isep/game/cards/Hand.java
+++ b/src/main/java/com/isep/game/cards/Hand.java
@@ -428,7 +428,10 @@ public class Hand
             }
         }
 
-        throw new RuntimeException("The current Hand does not have the cards required to build the provided stage !");
+        if(resourcesRequired > 0)
+            throw new RuntimeException("The current Hand does not have the cards required to build the provided stage !");
+
+        return requiredCards;
     }
 
     /**

--- a/src/main/java/com/isep/game/tokens/ProgressToken.java
+++ b/src/main/java/com/isep/game/tokens/ProgressToken.java
@@ -32,6 +32,12 @@ public class ProgressToken
         this.effect = effect;
     }
 
+    // Getters & Setters
+    public Effect getEffect()
+    {
+        return this.effect;
+    }
+
     // Methods
     @Override
     public String toString()

--- a/src/main/java/com/isep/game/wonders/Stage.java
+++ b/src/main/java/com/isep/game/wonders/Stage.java
@@ -25,6 +25,11 @@ public class Stage
     }
 
     // Getters & Setters
+    public int getVictoryPoints()
+    {
+        return this.victoryPoints;
+    }
+
     public int getRequiredResourcesAmount()
     {
         return this.requiredResourcesAmount;

--- a/src/main/java/com/isep/game/wonders/Wonder.java
+++ b/src/main/java/com/isep/game/wonders/Wonder.java
@@ -46,6 +46,22 @@ public abstract class Wonder
     }
 
     // Methods
+
+    /**
+     * Returns true if this {@link Wonder} is fully built.
+     * @return True if every {@link Stage} of this {@link Wonder} has been constructed.
+     */
+    public boolean isConstructed()
+    {
+        for(Stage stage: this.stages)
+        {
+            if(!stage.isConstructed())
+                return false;
+        }
+
+        return true;
+    }
+
     /**
      * Returns a {@link List<Stage>} containing the next {@link Stage}s that need to be built.
      * For instance, on a {@link Wonder} with 5 {@link Stage}s, if Stage 1 has been built, this method returns Stage 2.

--- a/src/main/java/com/isep/game/wonders/Wonder.java
+++ b/src/main/java/com/isep/game/wonders/Wonder.java
@@ -1,9 +1,11 @@
 package com.isep.game.wonders;
 
+import com.isep.game.Player;
 import com.isep.game.cards.Card;
 import com.isep.game.cards.Deck;
 import com.isep.game.Game;
 import com.isep.game.cards.Hand;
+import com.isep.game.tokens.ProgressToken;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -77,11 +79,12 @@ public abstract class Wonder
      * @param stage The {@link Stage} to build.
      * @param hand The {@link Hand} to use the {@link Card}s from.
      * @param discard The {@link Game}'s discard.
+     * @param economyEffect A boolean indicating if the {@link Player} owning this {@link Hand} has the ECONOMY {@link ProgressToken}.
      * @author Quentin LAURENT
      */
-    public void buildStage(Stage stage, Hand hand, Deck discard)
+    public void buildStage(Stage stage, Hand hand, Deck discard, boolean economyEffect)
     {
-        Map<Card, Integer> cardsRequired = hand.getCardsRequiredToBuildStage(stage);
+        Map<Card, Integer> cardsRequired = hand.getCardsRequiredToBuildStage(stage, economyEffect);
 
         // Removing the Cards from the provided Hand
         for(var entry: cardsRequired.entrySet())

--- a/src/main/java/com/isep/game/wonders/Wonder.java
+++ b/src/main/java/com/isep/game/wonders/Wonder.java
@@ -80,11 +80,12 @@ public abstract class Wonder
      * @param hand The {@link Hand} to use the {@link Card}s from.
      * @param discard The {@link Game}'s discard.
      * @param economyEffect A boolean indicating if the {@link Player} owning this {@link Hand} has the ECONOMY {@link ProgressToken}.
+     * @param engineeringEffect A boolean indicating if the {@link Player} owning this {@link Hand} has the ENGINEERING {@link ProgressToken}.
      * @author Quentin LAURENT
      */
-    public void buildStage(Stage stage, Hand hand, Deck discard, boolean economyEffect)
+    public void buildStage(Stage stage, Hand hand, Deck discard, boolean economyEffect, boolean engineeringEffect)
     {
-        Map<Card, Integer> cardsRequired = hand.getCardsRequiredToBuildStage(stage, economyEffect);
+        Map<Card, Integer> cardsRequired = hand.getCardsRequiredToBuildStage(stage, economyEffect, engineeringEffect);
 
         // Removing the Cards from the provided Hand
         for(var entry: cardsRequired.entrySet())

--- a/src/test/java/com/isep/game/GameTest.java
+++ b/src/test/java/com/isep/game/GameTest.java
@@ -32,10 +32,10 @@ class GameTest
         ArrayList<Stage> stages = new ArrayList<>();
         stages.add(alexandria.getStages().get(0));
 
-        assertTrue(player.getHand().canBuildStage(stages));
+        assertTrue(player.getHand().canBuildStage(stages, false));
 
         // Checking if the Stage has been built
-        alexandria.buildStage(alexandria.getStages().get(0), player.getHand(), new Deck());
+        alexandria.buildStage(alexandria.getStages().get(0), player.getHand(), new Deck(), false);
 
         assertTrue(alexandria.getStages().get(0).isConstructed());
 
@@ -66,10 +66,10 @@ class GameTest
         ArrayList<Stage> stages = new ArrayList<>();
         stages.add(alexandria.getStages().get(0));
 
-        assertTrue(player.getHand().canBuildStage(stages));
+        assertTrue(player.getHand().canBuildStage(stages, false));
 
         // Checking if the Stage has been built
-        alexandria.buildStage(alexandria.getStages().get(0), player.getHand(), new Deck());
+        alexandria.buildStage(alexandria.getStages().get(0), player.getHand(), new Deck(), false);
 
         assertTrue(alexandria.getStages().get(0).isConstructed());
 

--- a/src/test/java/com/isep/game/GameTest.java
+++ b/src/test/java/com/isep/game/GameTest.java
@@ -35,7 +35,7 @@ class GameTest
         assertTrue(player.getHand().canBuildStage(stages, false));
 
         // Checking if the Stage has been built
-        alexandria.buildStage(alexandria.getStages().get(0), player.getHand(), new Deck(), false);
+        alexandria.buildStage(alexandria.getStages().get(0), player.getHand(), new Deck(), false, false);
 
         assertTrue(alexandria.getStages().get(0).isConstructed());
 
@@ -69,7 +69,7 @@ class GameTest
         assertTrue(player.getHand().canBuildStage(stages, false));
 
         // Checking if the Stage has been built
-        alexandria.buildStage(alexandria.getStages().get(0), player.getHand(), new Deck(), false);
+        alexandria.buildStage(alexandria.getStages().get(0), player.getHand(), new Deck(), false, false);
 
         assertTrue(alexandria.getStages().get(0).isConstructed());
 

--- a/src/test/java/com/isep/game/cards/HandTest.java
+++ b/src/test/java/com/isep/game/cards/HandTest.java
@@ -106,7 +106,7 @@ class HandTest
 
         ArrayList<Stage> stages = new ArrayList<>();
         stages.add(stage1);
-        assertTrue(hand.canBuildStage(stages));
+        assertTrue(hand.canBuildStage(stages, false));
 
         // Stage 4 of Alexandria requires 3 identical resources
         Stage stage4 = new Alexandria().getStages().get(3);
@@ -119,7 +119,7 @@ class HandTest
 
         stages.clear();
         stages.add(stage4);
-        assertTrue(hand.canBuildStage(stages));
+        assertTrue(hand.canBuildStage(stages, false));
     }
 
     @Test
@@ -135,7 +135,7 @@ class HandTest
 
         ArrayList<Stage> stages = new ArrayList<>();
         stages.add(stage1);
-        assertTrue(hand.canBuildStage(stages));
+        assertTrue(hand.canBuildStage(stages, false));
 
         // Stage 4 of Alexandria requires 3 identical resources
         Stage stage4 = new Alexandria().getStages().get(3);
@@ -148,7 +148,7 @@ class HandTest
 
         stages.clear();
         stages.add(stage4);
-        assertTrue(hand.canBuildStage(stages));
+        assertTrue(hand.canBuildStage(stages, false));
     }
 
     @Test
@@ -163,7 +163,7 @@ class HandTest
 
         ArrayList<Stage> stages = new ArrayList<>();
         stages.add(stage1);
-        assertFalse(hand.canBuildStage(stages));
+        assertFalse(hand.canBuildStage(stages, false));
 
         // Stage 4 of Alexandria requires 3 identical resources
         Stage stage4 = new Alexandria().getStages().get(3);
@@ -175,7 +175,7 @@ class HandTest
 
         stages.clear();
         stages.add(stage4);
-        assertFalse(hand.canBuildStage(stages));
+        assertFalse(hand.canBuildStage(stages, false));
     }
 
     @Test
@@ -217,7 +217,7 @@ class HandTest
         ArrayList<Stage> stagesReadyToBuild = new ArrayList<Stage>();
         stagesReadyToBuild.add(babylon.getStages().get(3));
 
-        assertEquals(stagesReadyToBuild, hand.getStagesReadyToBuild(babylon.getNextStagesToBuild()));
+        assertEquals(stagesReadyToBuild, hand.getStagesReadyToBuild(babylon.getNextStagesToBuild(), false));
     }
 
     @Test
@@ -241,7 +241,7 @@ class HandTest
         stagesReadyToBuild.add(babylon.getStages().get(3));
         stagesReadyToBuild.add(babylon.getStages().get(4));
 
-        assertEquals(stagesReadyToBuild, hand.getStagesReadyToBuild(babylon.getNextStagesToBuild()));
+        assertEquals(stagesReadyToBuild, hand.getStagesReadyToBuild(babylon.getNextStagesToBuild(), false));
     }
 
     @Test
@@ -262,7 +262,7 @@ class HandTest
         ArrayList<Stage> stagesReadyToBuild = new ArrayList<Stage>();
         stagesReadyToBuild.add(babylon.getStages().get(3));
 
-        assertEquals(stagesReadyToBuild, hand.getStagesReadyToBuild(babylon.getNextStagesToBuild()));
+        assertEquals(stagesReadyToBuild, hand.getStagesReadyToBuild(babylon.getNextStagesToBuild(), false));
     }
 
     @Test
@@ -286,7 +286,7 @@ class HandTest
         stagesReadyToBuild.add(babylon.getStages().get(3));
         stagesReadyToBuild.add(babylon.getStages().get(4));
 
-        assertEquals(stagesReadyToBuild, hand.getStagesReadyToBuild(babylon.getNextStagesToBuild()));
+        assertEquals(stagesReadyToBuild, hand.getStagesReadyToBuild(babylon.getNextStagesToBuild(), false));
     }
 
     @Test
@@ -305,7 +305,7 @@ class HandTest
         cardsRequired.put(new GreyCard(GreyCard.Material.WOOD), 1);
         cardsRequired.put(new GreyCard(GreyCard.Material.STONE), 1);
 
-        assertEquals(cardsRequired, hand.getCardsRequiredToBuildStage(stage1));
+        assertEquals(cardsRequired, hand.getCardsRequiredToBuildStage(stage1, false));
 
         // Stage 4 of Alexandria requires three identical resources
         Stage stage4 = new Alexandria().getStages().get(3);
@@ -320,7 +320,7 @@ class HandTest
         cardsRequired.clear();
         cardsRequired.put(new GreyCard(GreyCard.Material.WOOD), 3);
 
-        assertEquals(cardsRequired, hand.getCardsRequiredToBuildStage(stage4));
+        assertEquals(cardsRequired, hand.getCardsRequiredToBuildStage(stage4, false));
     }
 
     @Test
@@ -339,7 +339,7 @@ class HandTest
         cardsRequired.put(new GreyCard(GreyCard.Material.WOOD), 1);
         cardsRequired.put(new YellowCard(), 1);
 
-        assertEquals(cardsRequired, hand.getCardsRequiredToBuildStage(stage1));
+        assertEquals(cardsRequired, hand.getCardsRequiredToBuildStage(stage1, false));
 
         // Stage 4 of Alexandria requires three identical resources
         Stage stage4 = new Alexandria().getStages().get(3);
@@ -355,7 +355,7 @@ class HandTest
         cardsRequired.put(new GreyCard(GreyCard.Material.WOOD), 2);
         cardsRequired.put(new YellowCard(), 1);
 
-        assertEquals(cardsRequired, hand.getCardsRequiredToBuildStage(stage4));
+        assertEquals(cardsRequired, hand.getCardsRequiredToBuildStage(stage4, false));
     }
 
     @Test
@@ -369,7 +369,7 @@ class HandTest
         hand1.addCard(new GreyCard(GreyCard.Material.WOOD), 3);
         hand1.addCard(new RedCard(0));
 
-        assertThrows(RuntimeException.class, () -> hand1.getCardsRequiredToBuildStage(stage1));
+        assertThrows(RuntimeException.class, () -> hand1.getCardsRequiredToBuildStage(stage1, false));
 
         // Stage 4 of Alexandria requires three identical resources
         Stage stage4 = new Alexandria().getStages().get(3);
@@ -381,7 +381,7 @@ class HandTest
         hand2.addCard(new GreyCard(GreyCard.Material.GLASS));
         hand2.addCard(new RedCard(0));
 
-        assertThrows(RuntimeException.class, () -> hand2.getCardsRequiredToBuildStage(stage4));
+        assertThrows(RuntimeException.class, () -> hand2.getCardsRequiredToBuildStage(stage4, false));
     }
 
     @Test

--- a/src/test/java/com/isep/game/cards/HandTest.java
+++ b/src/test/java/com/isep/game/cards/HandTest.java
@@ -123,6 +123,33 @@ class HandTest
     }
 
     @Test
+    void canBuildStageShouldReturnTrueWhenHandContainsCardsRequiredToBuildStageWithEngineeringEffect()
+    {
+        // Stage 1 of Alexandria requires 2 different resources
+        Stage stage1 = new Alexandria().getStages().get(0);
+        Hand hand = new Hand();
+        hand.addCard(new GreyCard(GreyCard.Material.WOOD));
+        hand.addCard(new GreenCard(GreenCard.ScienceSymbol.TABLET));
+        hand.addCard(new GreyCard(GreyCard.Material.WOOD));
+
+        ArrayList<Stage> stages = new ArrayList<>();
+        stages.add(stage1);
+        assertTrue(hand.canBuildStage(stages, false, true));
+
+        // Stage 4 of Alexandria requires 3 identical resources
+        Stage stage4 = new Alexandria().getStages().get(3);
+        hand = new Hand();
+        hand.addCard(new GreyCard(GreyCard.Material.WOOD));
+        hand.addCard(new GreenCard(GreenCard.ScienceSymbol.TABLET));
+        hand.addCard(new GreyCard(GreyCard.Material.PAPYRUS));
+        hand.addCard(new GreyCard(GreyCard.Material.GLASS));
+
+        stages.clear();
+        stages.add(stage4);
+        assertTrue(hand.canBuildStage(stages, false, true));
+    }
+
+    @Test
     void canBuildStageShouldReturnTrueWhenHandContainsCardsRequiredToBuildStageWithYellowCards()
     {
         // Stage 1 of Alexandria requires 2 different resources
@@ -149,6 +176,55 @@ class HandTest
         stages.clear();
         stages.add(stage4);
         assertTrue(hand.canBuildStage(stages, false));
+    }
+
+    @Test
+    void canBuildStageShouldReturnTrueWhenHandContainsCardsRequiredToBuildStageWithYellowCardsWithEconomyEffect()
+    {
+        // Stage 1 of Alexandria requires 2 different resources
+        Stage stage1 = new Alexandria().getStages().get(0);
+        Hand hand = new Hand();
+        hand.addCard(new YellowCard());
+
+        ArrayList<Stage> stages = new ArrayList<>();
+        stages.add(stage1);
+        assertTrue(hand.canBuildStage(stages, true));
+
+        // Stage 4 of Alexandria requires 3 identical resources
+        Stage stage4 = new Alexandria().getStages().get(3);
+        hand = new Hand();
+        hand.addCard(new GreyCard(GreyCard.Material.WOOD));
+        hand.addCard(new GreenCard(GreenCard.ScienceSymbol.TABLET));
+        hand.addCard(new GreyCard(GreyCard.Material.GLASS));
+        hand.addCard(new YellowCard());
+
+        stages.clear();
+        stages.add(stage4);
+        assertTrue(hand.canBuildStage(stages, true));
+    }
+
+    @Test
+    void canBuildStageShouldReturnTrueWhenHandContainsCardsRequiredToBuildStageWithYellowCardsWithEconomyWithEngineeringEffects()
+    {
+        // Stage 1 of Alexandria requires 2 different resources
+        Stage stage1 = new Alexandria().getStages().get(0);
+        Hand hand = new Hand();
+        hand.addCard(new YellowCard());
+
+        ArrayList<Stage> stages = new ArrayList<>();
+        stages.add(stage1);
+        assertTrue(hand.canBuildStage(stages, true));
+
+        // Stage 4 of Alexandria requires 3 identical resources
+        Stage stage4 = new Alexandria().getStages().get(3);
+        hand = new Hand();
+        hand.addCard(new GreyCard(GreyCard.Material.WOOD));
+        hand.addCard(new GreenCard(GreenCard.ScienceSymbol.TABLET));
+        hand.addCard(new YellowCard());
+
+        stages.clear();
+        stages.add(stage4);
+        assertTrue(hand.canBuildStage(stages, true, true));
     }
 
     @Test
@@ -221,6 +297,28 @@ class HandTest
     }
 
     @Test
+    void getStagesReadyToBeBuiltShouldReturnAllTheStagesReadyToBeBuiltWithEngineeringEffect()
+    {
+        Babylon babylon = new Babylon();
+        babylon.getStages().get(0).setConstructed(true);
+        babylon.getStages().get(1).setConstructed(true);
+        babylon.getStages().get(2).setConstructed(true);
+
+        // This hand can build Stage 4 of Babylon (but not Stage 5, which is at the same level (4) )
+        Hand hand = new Hand();
+        hand.addCard(new BlueCard(3, false));
+        hand.addCard(new GreyCard(GreyCard.Material.WOOD));
+        hand.addCard(new GreyCard(GreyCard.Material.GLASS));
+        hand.addCard(new GreyCard(GreyCard.Material.STONE));
+        hand.addCard(new RedCard(0));
+
+        ArrayList<Stage> stagesReadyToBuild = new ArrayList<Stage>();
+        stagesReadyToBuild.add(babylon.getStages().get(3));
+
+        assertEquals(stagesReadyToBuild, hand.getStagesReadyToBuild(babylon.getNextStagesToBuild(), false, true));
+    }
+
+    @Test
     void getStagesReadyToBeBuiltShouldReturnAllTheStagesReadyToBeBuiltWhenMultipleAreAvailable()
     {
         Babylon babylon = new Babylon();
@@ -245,6 +343,30 @@ class HandTest
     }
 
     @Test
+    void getStagesReadyToBeBuiltShouldReturnAllTheStagesReadyToBeBuiltWhenMultipleAreAvailableWithEngineeringEffect()
+    {
+        Babylon babylon = new Babylon();
+        babylon.getStages().get(0).setConstructed(true);
+        babylon.getStages().get(1).setConstructed(true);
+        babylon.getStages().get(2).setConstructed(true);
+
+        // This hand can build Stages 4 and 5 of Babylon
+        Hand hand = new Hand();
+        hand.addCard(new BlueCard(3, false));
+        hand.addCard(new GreyCard(GreyCard.Material.WOOD));
+        hand.addCard(new GreyCard(GreyCard.Material.BRICK));
+        hand.addCard(new GreyCard(GreyCard.Material.PAPYRUS));
+        hand.addCard(new GreyCard(GreyCard.Material.STONE));
+        hand.addCard(new RedCard(0));
+
+        ArrayList<Stage> stagesReadyToBuild = new ArrayList<Stage>();
+        stagesReadyToBuild.add(babylon.getStages().get(3));
+        stagesReadyToBuild.add(babylon.getStages().get(4));
+
+        assertEquals(stagesReadyToBuild, hand.getStagesReadyToBuild(babylon.getNextStagesToBuild(), false, true));
+    }
+
+    @Test
     void getStagesReadyToBeBuiltShouldReturnAllTheStagesReadyToBeBuiltWithYellowCards()
     {
         Babylon babylon = new Babylon();
@@ -263,6 +385,27 @@ class HandTest
         stagesReadyToBuild.add(babylon.getStages().get(3));
 
         assertEquals(stagesReadyToBuild, hand.getStagesReadyToBuild(babylon.getNextStagesToBuild(), false));
+    }
+
+    @Test
+    void getStagesReadyToBeBuiltShouldReturnAllTheStagesReadyToBeBuiltWithYellowCardsWithEconomyEffect()
+    {
+        Babylon babylon = new Babylon();
+        babylon.getStages().get(0).setConstructed(true);
+        babylon.getStages().get(1).setConstructed(true);
+        babylon.getStages().get(2).setConstructed(true);
+
+        // This hand can build Stage 4 of Babylon (but not Stage 5, which is at the same level (4) )
+        Hand hand = new Hand();
+        hand.addCard(new BlueCard(3, false));
+        hand.addCard(new GreyCard(GreyCard.Material.WOOD));
+        hand.addCard(new YellowCard());
+        hand.addCard(new RedCard(0));
+
+        ArrayList<Stage> stagesReadyToBuild = new ArrayList<Stage>();
+        stagesReadyToBuild.add(babylon.getStages().get(3));
+
+        assertEquals(stagesReadyToBuild, hand.getStagesReadyToBuild(babylon.getNextStagesToBuild(), true));
     }
 
     @Test
@@ -287,6 +430,48 @@ class HandTest
         stagesReadyToBuild.add(babylon.getStages().get(4));
 
         assertEquals(stagesReadyToBuild, hand.getStagesReadyToBuild(babylon.getNextStagesToBuild(), false));
+    }
+
+    @Test
+    void getStagesReadyToBeBuiltShouldReturnAllTheStagesReadyToBeBuiltWhenMultipleAreAvailableWithYellowCardsWithEconomyEffect()
+    {
+        Babylon babylon = new Babylon();
+        babylon.getStages().get(0).setConstructed(true);
+        babylon.getStages().get(1).setConstructed(true);
+        babylon.getStages().get(2).setConstructed(true);
+
+        // This hand can build Stages 4 and 5 of Babylon
+        Hand hand = new Hand();
+        hand.addCard(new BlueCard(3, false));
+        hand.addCard(new YellowCard(), 2);
+        hand.addCard(new RedCard(0));
+
+        ArrayList<Stage> stagesReadyToBuild = new ArrayList<Stage>();
+        stagesReadyToBuild.add(babylon.getStages().get(3));
+        stagesReadyToBuild.add(babylon.getStages().get(4));
+
+        assertEquals(stagesReadyToBuild, hand.getStagesReadyToBuild(babylon.getNextStagesToBuild(), true));
+    }
+
+    @Test
+    void getStagesReadyToBeBuiltShouldReturnAllTheStagesReadyToBeBuiltWhenMultipleAreAvailableWithYellowCardsWithEconomyWithEngineeringEffects()
+    {
+        Babylon babylon = new Babylon();
+        babylon.getStages().get(0).setConstructed(true);
+        babylon.getStages().get(1).setConstructed(true);
+        babylon.getStages().get(2).setConstructed(true);
+
+        // This hand can build Stages 4 and 5 of Babylon
+        Hand hand = new Hand();
+        hand.addCard(new BlueCard(3, false));
+        hand.addCard(new YellowCard(), 2);
+        hand.addCard(new RedCard(0));
+
+        ArrayList<Stage> stagesReadyToBuild = new ArrayList<Stage>();
+        stagesReadyToBuild.add(babylon.getStages().get(3));
+        stagesReadyToBuild.add(babylon.getStages().get(4));
+
+        assertEquals(stagesReadyToBuild, hand.getStagesReadyToBuild(babylon.getNextStagesToBuild(), true, true));
     }
 
     @Test
@@ -321,6 +506,40 @@ class HandTest
         cardsRequired.put(new GreyCard(GreyCard.Material.WOOD), 3);
 
         assertEquals(cardsRequired, hand.getCardsRequiredToBuildStage(stage4, false));
+    }
+
+    @Test
+    void getCardsRequiredToBuildStageShouldReturnCardsRequiredToBuildStageWithEngineeringEffect()
+    {
+        // Stage 1 of Alexandria requires two different resources
+        Stage stage1 = new Alexandria().getStages().get(0);
+
+        Hand hand = new Hand();
+        hand.addCard(new BlueCard(3, false));
+        hand.addCard(new GreyCard(GreyCard.Material.WOOD), 3);
+        hand.addCard(new RedCard(0));
+
+        HashMap<Card, Integer> cardsRequired = new HashMap<Card, Integer>();
+        cardsRequired.put(new GreyCard(GreyCard.Material.WOOD), 2);
+
+        assertEquals(cardsRequired, hand.getCardsRequiredToBuildStage(stage1, false, true));
+
+        // Stage 4 of Alexandria requires three identical resources
+        Stage stage4 = new Alexandria().getStages().get(3);
+
+        hand = new Hand();
+        hand.addCard(new BlueCard(3, false));
+        hand.addCard(new GreyCard(GreyCard.Material.WOOD));
+        hand.addCard(new GreyCard(GreyCard.Material.GLASS));
+        hand.addCard(new GreyCard(GreyCard.Material.STONE));
+        hand.addCard(new RedCard(0));
+
+        cardsRequired.clear();
+        cardsRequired.put(new GreyCard(GreyCard.Material.WOOD), 1);
+        cardsRequired.put(new GreyCard(GreyCard.Material.GLASS), 1);
+        cardsRequired.put(new GreyCard(GreyCard.Material.STONE), 1);
+
+        assertEquals(cardsRequired, hand.getCardsRequiredToBuildStage(stage4, false, true));
     }
 
     @Test
@@ -359,6 +578,68 @@ class HandTest
     }
 
     @Test
+    void getCardsRequiredToBuildStageShouldReturnCardsRequiredToBuildStageWithYellowCardsWithEconomyEffect()
+    {
+        // Stage 1 of Alexandria requires two different resources
+        Stage stage1 = new Alexandria().getStages().get(0);
+
+        Hand hand = new Hand();
+        hand.addCard(new BlueCard(3, false));
+        hand.addCard(new YellowCard());
+        hand.addCard(new RedCard(0));
+
+        HashMap<Card, Integer> cardsRequired = new HashMap<Card, Integer>();
+        cardsRequired.put(new YellowCard(), 1);
+
+        assertEquals(cardsRequired, hand.getCardsRequiredToBuildStage(stage1, true));
+
+        // Stage 4 of Alexandria requires three identical resources
+        Stage stage4 = new Alexandria().getStages().get(3);
+
+        hand = new Hand();
+        hand.addCard(new BlueCard(3, false));
+        hand.addCard(new GreyCard(GreyCard.Material.STONE));
+        hand.addCard(new YellowCard());
+        hand.addCard(new RedCard(0));
+
+        cardsRequired.clear();
+        cardsRequired.put(new GreyCard(GreyCard.Material.STONE), 1);
+        cardsRequired.put(new YellowCard(), 1);
+
+        assertEquals(cardsRequired, hand.getCardsRequiredToBuildStage(stage4, true));
+    }
+
+    @Test
+    void getCardsRequiredToBuildStageShouldReturnCardsRequiredToBuildStageWithYellowCardsWithEconomyAndEngineeringEffects()
+    {
+        // Stage 1 of Alexandria requires two different resources
+        Stage stage1 = new Alexandria().getStages().get(0);
+
+        Hand hand = new Hand();
+        hand.addCard(new BlueCard(3, false));
+        hand.addCard(new YellowCard());
+        hand.addCard(new RedCard(0));
+
+        HashMap<Card, Integer> cardsRequired = new HashMap<Card, Integer>();
+        cardsRequired.put(new YellowCard(), 1);
+
+        assertEquals(cardsRequired, hand.getCardsRequiredToBuildStage(stage1, true, true));
+
+        // Stage 4 of Alexandria requires three identical resources
+        Stage stage4 = new Alexandria().getStages().get(3);
+
+        hand = new Hand();
+        hand.addCard(new BlueCard(3, false));
+        hand.addCard(new YellowCard(), 2);
+        hand.addCard(new RedCard(0));
+
+        cardsRequired.clear();
+        cardsRequired.put(new YellowCard(), 2);
+
+        assertEquals(cardsRequired, hand.getCardsRequiredToBuildStage(stage4, true, true));
+    }
+
+    @Test
     void getCardsRequiredToBuildStageShouldThrowRuntimeExceptionIfStageCannotBeBuilt()
     {
         // Stage 1 of Alexandria requires two different resources
@@ -382,6 +663,78 @@ class HandTest
         hand2.addCard(new RedCard(0));
 
         assertThrows(RuntimeException.class, () -> hand2.getCardsRequiredToBuildStage(stage4, false));
+    }
+
+    @Test
+    void getCardsRequiredToBuildStageShouldThrowRuntimeExceptionIfStageCannotBeBuiltWithYellowCards()
+    {
+        // Stage 1 of Alexandria requires two different resources
+        Stage stage1 = new Alexandria().getStages().get(0);
+
+        final Hand hand1 = new Hand();
+        hand1.addCard(new BlueCard(3, false));
+        hand1.addCard(new YellowCard(), 1);
+        hand1.addCard(new RedCard(0));
+
+        assertThrows(RuntimeException.class, () -> hand1.getCardsRequiredToBuildStage(stage1, false));
+
+        // Stage 4 of Alexandria requires three identical resources
+        Stage stage4 = new Alexandria().getStages().get(3);
+
+        final Hand hand2 = new Hand();
+        hand2.addCard(new BlueCard(3, false));
+        hand2.addCard(new YellowCard(), 2);
+        hand2.addCard(new RedCard(0));
+
+        assertThrows(RuntimeException.class, () -> hand2.getCardsRequiredToBuildStage(stage4, false));
+    }
+
+    @Test
+    void getCardsRequiredToBuildStageShouldThrowRuntimeExceptionIfStageCannotBeBuiltWithYellowCardsWithEconomyEffect()
+    {
+        // Stage 1 of Alexandria requires three different resources
+        Stage stage3 = new Alexandria().getStages().get(2);
+
+        final Hand hand1 = new Hand();
+        hand1.addCard(new BlueCard(3, false));
+        hand1.addCard(new YellowCard());
+        hand1.addCard(new RedCard(0));
+
+        assertThrows(RuntimeException.class, () -> hand1.getCardsRequiredToBuildStage(stage3, true));
+
+        // Stage 4 of Alexandria requires three identical resources
+        Stage stage4 = new Alexandria().getStages().get(3);
+
+        final Hand hand2 = new Hand();
+        hand2.addCard(new BlueCard(3, false));
+        hand2.addCard(new YellowCard());
+        hand2.addCard(new RedCard(0));
+
+        assertThrows(RuntimeException.class, () -> hand2.getCardsRequiredToBuildStage(stage4, true));
+    }
+
+    @Test
+    void getCardsRequiredToBuildStageShouldThrowRuntimeExceptionIfStageCannotBeBuiltWithYellowCardsWithEconomyAndEngineeringEffects()
+    {
+        // Stage 1 of Alexandria requires three different resources
+        Stage stage3 = new Alexandria().getStages().get(2);
+
+        final Hand hand1 = new Hand();
+        hand1.addCard(new BlueCard(3, false));
+        hand1.addCard(new YellowCard());
+        hand1.addCard(new RedCard(0));
+
+        assertThrows(RuntimeException.class, () -> hand1.getCardsRequiredToBuildStage(stage3, true, true));
+
+        // Stage 4 of Alexandria requires three identical resources
+        Stage stage4 = new Alexandria().getStages().get(3);
+
+        final Hand hand2 = new Hand();
+        hand2.addCard(new BlueCard(3, false));
+        hand2.addCard(new YellowCard());
+        hand2.addCard(new RedCard(0));
+
+        assertThrows(RuntimeException.class, () -> hand2.getCardsRequiredToBuildStage(stage4, true, true));
     }
 
     @Test

--- a/src/test/java/com/isep/game/wonders/WonderTest.java
+++ b/src/test/java/com/isep/game/wonders/WonderTest.java
@@ -82,7 +82,7 @@ class WonderTest {
         hand.addCard(new GreyCard(GreyCard.Material.WOOD));
         hand.addCard(new GreyCard(GreyCard.Material.STONE));
 
-        babylon.buildStage(stage1, hand, new Deck(), false);
+        babylon.buildStage(stage1, hand, new Deck(), false, false);
 
         assertTrue(stage1.isConstructed());
     }
@@ -103,7 +103,7 @@ class WonderTest {
         expectedDiscard.addCard(new GreyCard(GreyCard.Material.WOOD));
         expectedDiscard.addCard(new GreyCard(GreyCard.Material.STONE));
 
-        babylon.buildStage(stage1, hand, game.getDiscard(), false);
+        babylon.buildStage(stage1, hand, game.getDiscard(), false, false);
 
         assertEquals(new Hand(), hand);
     }
@@ -124,7 +124,7 @@ class WonderTest {
         expectedDiscard.addCard(new GreyCard(GreyCard.Material.WOOD));
         expectedDiscard.addCard(new GreyCard(GreyCard.Material.STONE));
 
-        babylon.buildStage(stage1, hand, game.getDiscard(), false);
+        babylon.buildStage(stage1, hand, game.getDiscard(), false, false);
 
         assertTrue(game.getDiscard().getCards().containsAll(expectedDiscard.getCards()));
     }

--- a/src/test/java/com/isep/game/wonders/WonderTest.java
+++ b/src/test/java/com/isep/game/wonders/WonderTest.java
@@ -82,7 +82,7 @@ class WonderTest {
         hand.addCard(new GreyCard(GreyCard.Material.WOOD));
         hand.addCard(new GreyCard(GreyCard.Material.STONE));
 
-        babylon.buildStage(stage1, hand, new Deck());
+        babylon.buildStage(stage1, hand, new Deck(), false);
 
         assertTrue(stage1.isConstructed());
     }
@@ -103,7 +103,7 @@ class WonderTest {
         expectedDiscard.addCard(new GreyCard(GreyCard.Material.WOOD));
         expectedDiscard.addCard(new GreyCard(GreyCard.Material.STONE));
 
-        babylon.buildStage(stage1, hand, game.getDiscard());
+        babylon.buildStage(stage1, hand, game.getDiscard(), false);
 
         assertEquals(new Hand(), hand);
     }
@@ -124,7 +124,7 @@ class WonderTest {
         expectedDiscard.addCard(new GreyCard(GreyCard.Material.WOOD));
         expectedDiscard.addCard(new GreyCard(GreyCard.Material.STONE));
 
-        babylon.buildStage(stage1, hand, game.getDiscard());
+        babylon.buildStage(stage1, hand, game.getDiscard(), false);
 
         assertTrue(game.getDiscard().getCards().containsAll(expectedDiscard.getCards()));
     }


### PR DESCRIPTION
Support has been added for every effect granted by `ProgressToken`s, according to the rules below:

![image](https://user-images.githubusercontent.com/116287348/213892520-49fa2811-0e76-4592-9a15-7f0202604847.png)

Victory points calculation has also been added when the `Game` ends.